### PR TITLE
Use float as frameDuration cause kCGImagePropertyGIFDelayTime should take float and not double(NSTimeInterval)

### DIFF
--- a/AnimatedGIFImageSerialization/AnimatedGIFImageSerialization.m
+++ b/AnimatedGIFImageSerialization/AnimatedGIFImageSerialization.m
@@ -98,7 +98,7 @@ __attribute__((overloadable)) NSData * UIImageAnimatedGIFRepresentation(UIImage 
     NSDictionary *userInfo = nil;
     {
         size_t frameCount = image.images.count;
-        NSTimeInterval frameDuration = (duration <= 0.0 ? image.duration / frameCount : duration / frameCount);
+        float frameDuration = (duration <= 0.0 ? image.duration / frameCount : duration / frameCount);
         NSDictionary *frameProperties = @{
                                           (__bridge NSString *)kCGImagePropertyGIFDictionary: @{
                                                   (__bridge NSString *)kCGImagePropertyGIFDelayTime: @(frameDuration)


### PR DESCRIPTION
It didnt work with decimal numbers.