### PR TITLE
Fixed that there could be nil images in the image array

### DIFF
--- a/AnimatedGIFImageSerialization/AnimatedGIFImageSerialization.m
+++ b/AnimatedGIFImageSerialization/AnimatedGIFImageSerialization.m
@@ -53,8 +53,11 @@ __attribute__((overloadable)) UIImage * UIImageWithAnimatedGIFData(NSData *data,
 
             NSDictionary *properties = (__bridge_transfer NSDictionary *)CGImageSourceCopyPropertiesAtIndex(imageSource, idx, NULL);
             calculatedDuration += [[[properties objectForKey:(__bridge NSString *)kCGImagePropertyGIFDictionary] objectForKey:(__bridge  NSString *)kCGImagePropertyGIFDelayTime] doubleValue];
-
-            [mutableImages addObject:[UIImage imageWithCGImage:imageRef scale:scale orientation:UIImageOrientationUp]];
+            
+            UIImage *image = [UIImage imageWithCGImage:imageRef scale:scale orientation:UIImageOrientationUp];
+            if (image) {
+                [mutableImages addObject:image];
+            }
 
             CGImageRelease(imageRef);
         }


### PR DESCRIPTION
This fixes that the images array could contain an nil image if the loaded gif contains a broken frame.
