### PR TITLE
Bumping version to accomodate bugfix for -[UIImage imageWithData:scale:] fixes #25

### DIFF
--- a/AnimatedGIFImageSerialization.podspec
+++ b/AnimatedGIFImageSerialization.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name     = 'AnimatedGIFImageSerialization'
-  s.version  = '0.2.0'
+  s.version  = '0.2.1'
   s.license  = 'MIT'
   s.summary  = 'Decodes UIImage sequences from Animated GIFs.'
   s.homepage = 'https://github.com/mattt/AnimatedGIFImageSerialization'
   s.social_media_url = 'https://twitter.com/mattt'
   s.authors  = { 'Mattt Thompson' => 'm@mattt.me' }
-  s.source   = { :git => 'https://github.com/mattt/AnimatedGIFImageSerialization.git', :tag => '0.2.0' }
+  s.source   = { :git => 'https://github.com/mattt/AnimatedGIFImageSerialization.git', :tag => '0.2.1' }
   s.source_files = 'AnimatedGIFImageSerialization'
   s.requires_arc = true
 


### PR DESCRIPTION
PR to request a version bump that includes the `-imageWithData:scale:` fix. Tag will still need to be created but I figured if I created an issue I could at least propose a solution.

Thank you for this library.
